### PR TITLE
Implement article detail page

### DIFF
--- a/fullstack_blog/app/routes.py
+++ b/fullstack_blog/app/routes.py
@@ -172,12 +172,10 @@ def delete_article_api(article_id):
     if article.author != current_user:
         return jsonify({'error': 'Action non autorisée'}), 403
 
-    # Supprimer l'image associée s'il y en a une
     if article.image_filename:
         try:
             os.remove(os.path.join(current_app.config['UPLOAD_FOLDER'], article.image_filename))
         except OSError as e:
-            # Logguer l'erreur mais continuer la suppression de l'article de la BDD
             current_app.logger.error(f"Erreur lors de la suppression du fichier image {article.image_filename}: {e}")
             pass
 
@@ -194,6 +192,11 @@ def uploaded_file(filename):
 @main_bp.route('/')
 def serve_index():
     return render_template('index.html')
+
+@main_bp.route('/article/<int:article_id>')
+def serve_article_detail(article_id):
+    article = Article.query.get_or_404(article_id)
+    return render_template('article_detail.html', article=article)
 
 @main_bp.route('/create-article')
 @login_required

--- a/fullstack_blog/app/static/js/main.js
+++ b/fullstack_blog/app/static/js/main.js
@@ -20,7 +20,7 @@ async function loadArticles(currentUserId) {
         articles.forEach(article => {
             const articleElement = document.createElement('div');
             articleElement.classList.add('article');
-            articleElement.setAttribute('id', `article-${article.id}`); // Ajout d'un ID à l'élément article
+            articleElement.setAttribute('id', `article-${article.id}`);
 
             let imageHTML = '';
             if (article.image_url) {
@@ -28,9 +28,7 @@ async function loadArticles(currentUserId) {
             }
 
             let actionsHTML = '';
-            // Vérifier si l'utilisateur actuel est l'auteur de l'article
             if (currentUserId && article.user_id === currentUserId) {
-                // Ajout de marge (par exemple, avec des classes CSS ou des espaces non sécables)
                 actionsHTML = `
                     <a href="/article/${article.id}/edit" class="edit-link action-link" style="margin-left: 10px;">Modifier</a>
                     <button class="delete-button action-link" data-article-id="${article.id}" style="margin-left: 10px;">Supprimer</button>
@@ -43,14 +41,13 @@ async function loadArticles(currentUserId) {
                 <p>${escapeHTML(article.content.substring(0, 200))}...</p>
                 ${imageHTML}
                 <div class="article-actions">
-                    <a href="#" onclick="showArticleDetail(${article.id}); return false;" class="action-link">Lire la suite</a>
+                    <a href="/article/${article.id}" class="action-link">Lire la suite</a>
                     ${actionsHTML}
                 </div>
             `;
             articlesListDiv.appendChild(articleElement);
         });
 
-        // Ajouter les écouteurs d'événements pour les boutons de suppression après leur création
         document.querySelectorAll('.delete-button').forEach(button => {
             button.addEventListener('click', handleDeleteArticle);
         });
@@ -71,9 +68,6 @@ async function handleDeleteArticle(event) {
     try {
         const response = await fetch(`/api/articles/${articleId}`, {
             method: 'DELETE',
-            // Headers CSRF peuvent être nécessaires ici si Flask-WTF ou Flask-SeaSurf est utilisé pour la protection CSRF globale
-            // Exemple pour Flask-WTF avec meta tag:
-            // headers: { 'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').getAttribute('content') }
         });
 
         if (response.ok) {
@@ -81,8 +75,6 @@ async function handleDeleteArticle(event) {
             if (articleElement) {
                 articleElement.remove();
             }
-            // Afficher un message de succès discret, ou ne rien faire pour une UX plus fluide.
-            // Un message global pourrait être affiché en haut de la page.
             console.log(`Article ${articleId} supprimé.`);
 
             const articlesListDiv = document.getElementById('articles-list');
@@ -161,10 +153,10 @@ function escapeHTML(str) {
         .replace(/'/g, '&#039;');
 }
 
-// Fonction pour afficher le détail d'un article (placeholder)
-function showArticleDetail(articleId) {
-    alert(`Affichage du détail pour l'article ID: ${articleId}. (Fonctionnalité de page de détail non implémentée)`);
-}
+// La fonction showArticleDetail n'est plus nécessaire car on redirige directement.
+// function showArticleDetail(articleId) {
+//     alert(`Affichage du détail pour l'article ID: ${articleId}. (Fonctionnalité de page de détail non implémentée)`);
+// }
 
 // Note: Les appels à loadArticles() et handleCreateArticleForm() sont faits
 // directement dans les templates HTML (index.html, create_article.html)

--- a/fullstack_blog/app/templates/article_detail.html
+++ b/fullstack_blog/app/templates/article_detail.html
@@ -1,0 +1,129 @@
+{% extends "base.html" %}
+
+{% block title %}{{ article.title }} - Mon Blog{% endblock %}
+
+{% block content %}
+<article class="article-detail">
+    <h1>{{ article.title }}</h1>
+    <p class="article-meta">
+        Par : <span class="author-name">{{ article.author.username }}</span> |
+        Publié le : <span class="publish-date">{{ article.created_at.strftime('%d %B %Y à %Hh%M') }}</span>
+    </p>
+
+    {% if article.image_filename %}
+    <div class="article-image-full">
+        <img src="{{ url_for('main.uploaded_file', filename=article.image_filename) }}" alt="{{ article.title }}">
+    </div>
+    {% endif %}
+
+    <div class="article-content-full">
+        {{ article.content | safe }} {# Utiliser |safe si le contenu peut contenir du HTML formaté par un éditeur riche. Sinon, échapper. #}
+        {# Pour du contenu en texte brut avec des sauts de ligne, on pourrait utiliser une balise <pre> ou du CSS white-space: pre-wrap #}
+        {# Si le contenu est du Markdown, il faudrait le convertir en HTML ici avec une extension comme Flask-Markdown #}
+    </div>
+
+    {% if current_user.is_authenticated and current_user.id == article.user_id %}
+    <div class="article-actions-detail">
+        <a href="{{ url_for('main.serve_edit_article_form', article_id=article.id) }}" class="btn btn-primary">Modifier l'article</a>
+        {# Le bouton de suppression appellera la même fonction JS que sur la page d'accueil #}
+        {# Il faut s'assurer que main.js est inclus et que la fonction handleDeleteArticle est globale ou accessible #}
+        {# Pour simplifier ici, on peut juste faire un lien vers une future route de confirmation de suppression ou un simple bouton #}
+        {# qui déclenche le JS. Le JS actuel ajoute les listeners aux boutons avec la classe .delete-button #}
+        <button class="delete-button btn btn-danger" data-article-id="{{ article.id }}" style="margin-left: 10px;">Supprimer l'article</button>
+    </div>
+    {% endif %}
+
+    <a href="{{ url_for('main.serve_index') }}" class="btn btn-secondary" style="margin-top: 20px;">Retour à la liste des articles</a>
+
+</article>
+
+{# S'assurer que main.js est chargé pour la fonctionnalité de suppression si besoin, ou dupliquer/adapter la logique JS ici #}
+{# Si main.js est déjà dans base.html dans le bloc scripts, c'est bon. #}
+{# Il faut aussi que currentUserId soit disponible pour handleDeleteArticle si elle l'utilise directement. #}
+{# Pour l'instant, on suppose que handleDeleteArticle de main.js est fonctionnel. #}
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }} {# Inclut les scripts de base.html (si main.js y est, c'est bon) #}
+    {# Si currentUserId est nécessaire pour handleDeleteArticle et n'est pas global, il faut le passer ici aussi #}
+    {% if current_user.is_authenticated %}
+    <script>
+        // Rendre currentUserId disponible si ce n'est pas déjà fait globalement par base.html ou index.html
+        // Cependant, handleDeleteArticle ne l'utilise pas directement, il utilise data-article-id.
+        // La vérification de l'auteur se fait côté serveur pour la suppression.
+        // const currentUserId = {{ current_user.id | tojson }}; // Probablement pas nécessaire ici pour la suppression.
+
+        // Assurer que les écouteurs pour les boutons de suppression sont attachés
+        // si ce n'est pas déjà fait par un script global.
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.delete-button').forEach(button => {
+                button.addEventListener('click', handleDeleteArticle);
+            });
+        });
+    </script>
+    {% endif %}
+    <style>
+        .article-detail {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .article-meta {
+            font-size: 0.9em;
+            color: #666;
+            margin-bottom: 20px;
+        }
+        .article-meta .author-name {
+            font-weight: bold;
+        }
+        .article-image-full img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+        .article-content-full {
+            line-height: 1.7;
+            white-space: pre-wrap; /* Pour respecter les sauts de ligne du contenu texte */
+        }
+        .article-actions-detail {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #eee;
+        }
+        .btn {
+            display: inline-block;
+            padding: 8px 15px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 0.9em;
+            text-align: center;
+            cursor: pointer;
+        }
+        .btn-primary {
+            background-color: #007bff;
+            color: white;
+            border: 1px solid #007bff;
+        }
+        .btn-primary:hover {
+            background-color: #0056b3;
+        }
+        .btn-danger {
+            background-color: #dc3545;
+            color: white;
+            border: 1px solid #dc3545;
+        }
+        .btn-danger:hover {
+            background-color: #c82333;
+        }
+        .btn-secondary {
+            background-color: #6c757d;
+            color: white;
+            border: 1px solid #6c757d;
+        }
+        .btn-secondary:hover {
+            background-color: #545b62;
+        }
+    </style>
+{% endblock %}


### PR DESCRIPTION
- Created an `article_detail.html` template to display the full article content, author, date, and image.
- Added a Flask route `/article/<int:article_id>` to serve the article detail page.
- Updated the "Lire la suite" (Read more) links on the homepage to navigate to the corresponding article's detail page.
- Integrated "Edit" and "Delete" buttons on the detail page, visible only to the article's author.
- Described manual tests for verifying the new functionality.