### PR TITLE
Fix: Resolve NameError for 'Comment' in routes

### DIFF
--- a/fullstack_blog/app/routes.py
+++ b/fullstack_blog/app/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify, current_app, send_from_directory, render_template, flash, redirect, url_for, abort
 from app import db, bcrypt # Importer db et bcrypt depuis le package app
-from app.models import Article, User # Importer User
+from app.models import Article, User, Comment # Importer Comment explicitement
 from flask_login import login_user, logout_user, current_user, login_required
 import os
 from werkzeug.utils import secure_filename


### PR DESCRIPTION
Imported the Comment model explicitly in app/routes.py to resolve a NameError when querying comments in the `serve_article_detail` route.