### PR TITLE
Fix: Remove nl2br filter and rely on CSS for comment line breaks

### DIFF
--- a/fullstack_blog/app/templates/article_detail.html
+++ b/fullstack_blog/app/templates/article_detail.html
@@ -61,7 +61,7 @@
                     <strong>{{ comment.author.username }}</strong>
                     <span class="comment-date">le {{ comment.timestamp.strftime('%d %b %Y à %Hh%M') }}</span>
                 </p>
-                <p class="comment-content">{{ comment.content | nl2br }}</p>
+                <p class="comment-content">{{ comment.content }}</p> {# Filtre nl2br retiré #}
             </div>
             {% endfor %}
         {% else %}


### PR DESCRIPTION
Removed the non-standard `nl2br` Jinja2 filter from the comment display in `article_detail.html`.
The `comment-content` class already has `white-space: pre-wrap;` CSS property, which correctly handles newline rendering.