### PR TITLE
Fix: Resolve UndefinedError for 'csrf_token' in JS comment

### DIFF
--- a/fullstack_blog/app/templates/article_detail.html
+++ b/fullstack_blog/app/templates/article_detail.html
@@ -207,8 +207,9 @@
                         const response = await fetch(`/api/article/${articleId}/like`, {
                             method: 'POST',
                             headers: {
-                                'Accept': 'application/json',
-                                // 'X-CSRFToken': '{{ csrf_token() }}' // Si CSRF est actif via Flask-WTF pour les POST AJAX
+                                'Accept': 'application/json'
+                                // Exemple d'en-tête CSRF si Flask-WTF est utilisé:
+                                // 'X-CSRFToken': 'VALEUR_DU_JETON_CSRF_ICI'
                             }
                         });
                         const result = await response.json();


### PR DESCRIPTION
Modified a JavaScript comment in `article_detail.html` that was incorrectly trying to use a Jinja2 expression `{{ csrf_token() }}`. The comment has been rephrased to prevent Jinja2 from processing it, thus resolving the UndefinedError.